### PR TITLE
Update supported versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,13 @@
 ## Supported Versions
 
 The maintainers of openHAB are usually only working on the main branch on code, i.e. on the next release, which is currently 3.1.0.
-As the currently officially supported versions are 2.5.x and 3.0.x, security patches will be considered for it, depending on their severity.
+As the currently officially supported version is 3.0.x, security patches will be considered for it, depending on their severity.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.5.x   | :white_check_mark: |
 | 3.0.x   | :white_check_mark: |
 | 3.1.0   | :white_check_mark: |
-| < 2.5   | :x:                |
+| < 3.0   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Because of the Bintray sunset it is difficult to continue 2.5.x support.